### PR TITLE
Simple Redux Implementation, including React Router Redux

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,7 +5,10 @@ module.exports = {
     'es6': true,
     'node': true,
   },
-  'extends': 'eslint:recommended',
+  'extends': [
+    'eslint:recommended',
+    'plugin:react/recommended',
+  ],
   'installedESLint': true,
   'parserOptions': {
     'ecmaFeatures': {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -38,5 +38,18 @@ module.exports = {
       'error',
       'never',
     ],
+    'comma-spacing': [
+      'error',
+      {
+        'before': false,
+        'after': true,
+      }
+    ],
+    'no-unused-vars': [
+      'error',
+      {
+        'args': 'none',
+      },
+    ]
   }
 }

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ compatible JavaScript.
 | folder             | contents                                                |
 |--------------------|---------------------------------------------------------|
 | ./src              | JavaScript Source Files                                 |
+| ./src/reducers     | The Redux Reducers                                      |
+| ./src/actions      | The Redux Actions                                       |
 
 ## NPM Commands
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
     "html-webpack-plugin": "^2.22.0",
     "react": "^15.3.1",
     "react-dom": "^15.3.1",
+    "react-redux": "^4.4.5",
     "react-router": "^2.7.0",
+    "redux": "^3.5.2",
     "webpack": "^1.13.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "react-dom": "^15.3.1",
     "react-redux": "^4.4.5",
     "react-router": "^2.7.0",
+    "react-router-redux": "^4.0.5",
     "redux": "^3.5.2",
     "webpack": "^1.13.2"
   },

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -1,6 +1,9 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
+import { Provider } from 'react-redux'
 import { Router, IndexRoute, Route, browserHistory } from 'react-router'
+
+import store from './store'
 
 const HelloMessage = React.createClass({
   render() {
@@ -12,12 +15,14 @@ const AppLayout = (props) => <div>{props.children}</div>
 
 const App = () => {
   return (
-    <Router history={browserHistory}>
-      <Route path='/' component={AppLayout}>
-        <IndexRoute component={HelloMessage} />
-        <Route path='/:name' component={HelloMessage} />
-      </Route>
-    </Router>
+    <Provider store={store}>
+      <Router history={browserHistory}>
+        <Route path='/' component={AppLayout}>
+          <IndexRoute component={HelloMessage} />
+          <Route path='/:name' component={HelloMessage} />
+        </Route>
+      </Router>
+    </Provider>
   )
 }
 

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -2,8 +2,10 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import { Provider } from 'react-redux'
 import { Router, IndexRoute, Route, browserHistory } from 'react-router'
+import { syncHistoryWithStore } from 'react-router-redux'
 
 import store from './store'
+const history = syncHistoryWithStore(browserHistory, store)
 
 const HelloMessage = React.createClass({
   render() {
@@ -16,7 +18,7 @@ const AppLayout = (props) => <div>{props.children}</div>
 const App = () => {
   return (
     <Provider store={store}>
-      <Router history={browserHistory}>
+      <Router history={history}>
         <Route path='/' component={AppLayout}>
           <IndexRoute component={HelloMessage} />
           <Route path='/:name' component={HelloMessage} />

--- a/src/reducers/index.jsx
+++ b/src/reducers/index.jsx
@@ -1,0 +1,7 @@
+function rootReducer(state = {}, action){
+  return {
+
+  }
+}
+
+export default rootReducer

--- a/src/reducers/index.jsx
+++ b/src/reducers/index.jsx
@@ -1,7 +1,10 @@
-function rootReducer(state = {}, action){
-  return {
+import { combineReducers } from 'redux'
+import { routerReducer } from 'react-router-redux'
 
+const rootReducer = combineReducers(
+  {
+    routing: routerReducer,
   }
-}
+)
 
 export default rootReducer

--- a/src/store.jsx
+++ b/src/store.jsx
@@ -1,0 +1,6 @@
+import { createStore } from 'redux'
+import rootReducer from './reducers'
+
+let store = createStore(rootReducer)
+
+export default store

--- a/src/store.jsx
+++ b/src/store.jsx
@@ -1,6 +1,12 @@
-import { createStore } from 'redux'
+import { createStore, compose } from 'redux'
 import rootReducer from './reducers'
 
-let store = createStore(rootReducer)
+const initialState = {}
+
+const middleware = compose(
+  window.devToolsExtension && window.devToolsExtension()
+)
+
+let store = createStore(rootReducer, initialState, middleware)
 
 export default store

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,5 +24,9 @@ module.exports = {
   devServer: {
     historyApiFallback: true,
   },
+  resolve: {
+    root: [__dirname],
+    extensions: [ '', '.jsx', '.js' ],
+  },
   plugins,
 }


### PR DESCRIPTION
A minimal setup of Redux, initially just holding the routing state.

`combineReducers` in `src/reducers/index.jsx` will make adding new reducers simpler as additional parts are added to the store.

Using `react-router-redux` means that navigation will work when using the time tracking features of the Redux DevTools and that you can sync the state to localStorage allowing the web app to work when added to the iOS Home screen.