### PR TITLE
Add Coveralls for Code Coverage reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 build
 npm-debug.log
+coverage

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # React Seed
 
-[![Coverage Status](https://coveralls.io/repos/github/OddEssay/react-seed/badge.svg?branch=feature%2Fcode-coverage)](https://coveralls.io/github/OddEssay/react-seed?branch=feature%2Fcode-coverage)
+[![Coverage Status](https://coveralls.io/repos/github/OddEssay/react-seed/badge.svg?branch=master](https://coveralls.io/github/OddEssay/react-seed?branch=master)
 
 ## Build Packages
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # React Seed
 
+[![Coverage Status](https://coveralls.io/repos/github/OddEssay/react-seed/badge.svg?branch=feature%2Fcode-coverage)](https://coveralls.io/github/OddEssay/react-seed?branch=feature%2Fcode-coverage)
+
 ## Build Packages
 
 ### webpack

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # React Seed
 
 [![Run Status](https://api.shippable.com/projects/57d043eb0630640f004d4dcc/badge?branch=master)](https://app.shippable.com/projects/57d043eb0630640f004d4dcc)
-[![Coverage Status](https://coveralls.io/repos/github/OddEssay/react-seed/badge.svg?branch=master](https://coveralls.io/github/OddEssay/react-seed?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/OddEssay/react-seed/badge.svg?branch=master)](https://coveralls.io/github/OddEssay/react-seed?branch=master)
 
 ## Build Packages
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # React Seed
 
+[![Run Status](https://api.shippable.com/projects/57d043eb0630640f004d4dcc/badge?branch=master)](https://app.shippable.com/projects/57d043eb0630640f004d4dcc)
 [![Coverage Status](https://coveralls.io/repos/github/OddEssay/react-seed/badge.svg?branch=master](https://coveralls.io/github/OddEssay/react-seed?branch=master)
 
 ## Build Packages

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "src/app.jsx",
   "scripts": {
     "start": "webpack-dev-server --hot --progress --colors --inline",
-    "test": "jest"
+    "test": "jest",
+    "cover": "jest --coverage"
   },
   "keywords": [
     "react"
@@ -21,6 +22,7 @@
     "babel-plugin-transform-react-jsx": "^6.8.0",
     "babel-polyfill": "^6.13.0",
     "babel-preset-es2015": "^6.14.0",
+    "coveralls": "^2.11.12",
     "eslint-plugin-jsx": "0.0.2",
     "eslint-plugin-react": "^6.2.2",
     "firebase": "^3.4.0",

--- a/shippable.yml
+++ b/shippable.yml
@@ -4,6 +4,8 @@ node_js:
   - 4.2.3
 env:
   - NODE_ENV=production
+  - COVERALLS_SERVICENAME=react-seed
+  - secure: epi8rDYaqnQ1dnSAGunP0J79npu7Umpi2zBpTCeUtPJAR79AKfaVNAAaeSG2YyiT0wF5vSNQtzXmLfgZIoVeb3CPkYHlBOn6mgkHoRhuhvAs1CWb5NtfS5SU0mJGRXXWEq+McBpAIYSnE+LD5O96/UY96vGk1TghwTeNhSaO8zh8cK1/lvygemsuFiyYu/vUbbegctPZ8zCp4LMBn/ThoHAzUNEJyrFHN1+tp6+MJ8GRKWtV8SOYhl+oQUe420ei8umSqjl4wO3b6BxECCZmNqfeU4xwPmOaNOQ0FHL4RgZL6ILYgoBkYLiNAE+8MATIbVVklFSoiGoDSvLKMgSU8A==
 build:
   pre_ci_boot:
     image_name: drydock/u14nod
@@ -12,6 +14,8 @@ build:
   ci:
     - npm install
     - npm test
+    - npm run cover
+    - cat coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
   cache: true
   cache_dir_list:
     - $SHIPPABLE_BUILD_DIR/node_modules

--- a/shippable.yml
+++ b/shippable.yml
@@ -3,9 +3,7 @@ node_js:
   - 6.2.0 
   - 4.2.3
 env:
-  - NODE_ENV=production
-  - COVERALLS_SERVICENAME=react-seed
-  - secure: epi8rDYaqnQ1dnSAGunP0J79npu7Umpi2zBpTCeUtPJAR79AKfaVNAAaeSG2YyiT0wF5vSNQtzXmLfgZIoVeb3CPkYHlBOn6mgkHoRhuhvAs1CWb5NtfS5SU0mJGRXXWEq+McBpAIYSnE+LD5O96/UY96vGk1TghwTeNhSaO8zh8cK1/lvygemsuFiyYu/vUbbegctPZ8zCp4LMBn/ThoHAzUNEJyrFHN1+tp6+MJ8GRKWtV8SOYhl+oQUe420ei8umSqjl4wO3b6BxECCZmNqfeU4xwPmOaNOQ0FHL4RgZL6ILYgoBkYLiNAE+8MATIbVVklFSoiGoDSvLKMgSU8A==
+  - secure: pmyHk1tM2/+zNuLMuG65witxUauw/Oo+nF+JfPZwDDigP3rCBFcUz0O0ljm/ZMLEjGQdhOLlVsEmnmX7pbuvObhPBcC/FfOX30Qm+iZ72WJNOFBoby+4FX2DubSwdp5xb/2TSjFWkw6220V0L2k+RqReuIRCCpSA+HDL9x7kt/mQzIXKNk2JVxezFAfDzbVtbm8ppLGD7e+U2ugt8B9/OtO10bjfl4E9zNBL2yfroAS5RNRUG36Jks1CUTZh8tPuQM5IAmfqC8GRgWv3izkPU1/g3a+z0rUsvnnE5Op718pdvsbL8/pwmAxpIZ6WjulFBM47Mw2gzZDwbfWnJSHoDg==
 build:
   pre_ci_boot:
     image_name: drydock/u14nod


### PR DESCRIPTION
The enviroment variables for Coveralls are stored in a secure shippable config - not ideal, and adds a little friction to cloning the project so at some point need to be moved into a config file.